### PR TITLE
unify initWithVCK spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ These attributes are implemented:
 
 ## Changelog
 
+Release 1.0.3:
+- Rename `Initializer.initWithVck` to `Initializer.initWithVCK`
+
 Release 1.0.2:
 - Update to VC-K 4.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 1.0.2
+artifactVersion = 1.0.3
 jdk.version=17

--- a/mobiledrivinglicence/src/commonMain/kotlin/at/asitplus/wallet/mdl/Initializer.kt
+++ b/mobiledrivinglicence/src/commonMain/kotlin/at/asitplus/wallet/mdl/Initializer.kt
@@ -17,14 +17,14 @@ object Initializer {
      * A reference to this class is enough to trigger the init block
      */
     init {
-        initWithVck()
+        initWithVCK()
     }
 
     /**
      * This has to be called first, before anything first, to load the
      * relevant classes of this library into the base implementations of VC-K
      */
-    fun initWithVck() {
+    fun initWithVCK() {
         LibraryInitializer.registerExtensionLibrary(
             credentialScheme = MobileDrivingLicenceScheme,
             serializerLookup = serializerLookup(),

--- a/mobiledrivinglicence/src/commonTest/kotlin/at/asitplus/wallet/mdl/KotestConfig.kt
+++ b/mobiledrivinglicence/src/commonTest/kotlin/at/asitplus/wallet/mdl/KotestConfig.kt
@@ -4,6 +4,6 @@ import io.kotest.core.config.AbstractProjectConfig
 
 class KotestConfig : AbstractProjectConfig() {
     init {
-        Initializer.initWithVck()
+        Initializer.initWithVCK()
     }
 }


### PR DESCRIPTION
Unifies the spelling of the init function with all other credential init functions.